### PR TITLE
Enable rating-server to access config server via eureka discovery.

### DIFF
--- a/hackster-service/src/main/resources/bootstrap.properties
+++ b/hackster-service/src/main/resources/bootstrap.properties
@@ -1,0 +1,3 @@
+spring.cloud.config.discovery.enabled=true
+spring.cloud.config.fail-fast=true
+spring.cloud.config.discovery.serviceId=config-server

--- a/rating-service/src/main/resources/bootstrap.properties
+++ b/rating-service/src/main/resources/bootstrap.properties
@@ -1,0 +1,3 @@
+spring.cloud.config.discovery.enabled=true
+spring.cloud.config.fail-fast=true
+spring.cloud.config.discovery.serviceId=config-server


### PR DESCRIPTION
Enable connect of rating server to config server not via default settings but using eureka discovery.
Wasn't able to test with dockers test branch.