### PR TITLE
added info level to testcontainers output

### DIFF
--- a/client-service/src/test/resources/logback-test.xml
+++ b/client-service/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.testcontainers.shaded.com.github.dockerjava.core.async.ResultCallbackTemplate" level="OFF"/>
+</configuration>

--- a/hackster-service-client/src/test/resources/logback-test.xml
+++ b/hackster-service-client/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.testcontainers.shaded.com.github.dockerjava.core.async.ResultCallbackTemplate" level="OFF"/>
+</configuration>

--- a/rating-service-client/src/test/resources/logback-test.xml
+++ b/rating-service-client/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.testcontainers.shaded.com.github.dockerjava.core.async.ResultCallbackTemplate" level="OFF"/>
+</configuration>

--- a/storage-service-client/src/test/resources/logback-test.xml
+++ b/storage-service-client/src/test/resources/logback-test.xml
@@ -1,0 +1,7 @@
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <logger name="org.testcontainers" level="INFO"/>
+    <logger name="org.testcontainers.shaded.com.github.dockerjava.core.async.ResultCallbackTemplate" level="OFF"/>
+</configuration>


### PR DESCRIPTION
We have a TRACE level for test containers framework output.
Logs are overloaded.
Downgrade default level to INFO for all integration TC tests.